### PR TITLE
[ refactor ] General refactoring and cleanup

### DIFF
--- a/docs/src/Examples/Balls.md
+++ b/docs/src/Examples/Balls.md
@@ -345,7 +345,6 @@ by registering an event handler upon initialization.
 Function `Web.MVC.Animate.animate` will respond with a
 cleanup hook, which we put in the `cleanup` field of the
 application state.
-```
 
 <!-- vi: filetype=idris2:syntax=markdown
 -->

--- a/docs/src/Examples/Balls.md
+++ b/docs/src/Examples/Balls.md
@@ -336,7 +336,7 @@ display (NumIn x)      _ = validate txtCount x <+> disabledE btnRun x
 display (Next m)       s =
   batch
     [ render out (ballsToScene s.balls)
-    , updateIf (s.count == 0) (text log $ showFPS s.dtime)
+    , cmdIf (s.count == 0) (text log $ showFPS s.dtime)
     ]
 ```
 

--- a/docs/src/Examples/Balls.md
+++ b/docs/src/Examples/Balls.md
@@ -124,7 +124,7 @@ record BallsST where
   count    : Nat
   dtime    : DTime
   numBalls : Maybe NumBalls
-  cleanUp  : IO ()
+  cleanup  : IO ()
 
 fpsCount : Nat
 fpsCount = 15
@@ -147,7 +147,7 @@ taken to animate 15 frames (`fpsCount`) and reduce a counter
 (`count`) on every frame.
 
 Second: We want to make sure the animation is stopped once the user
-selects another example application. Field `cleanUp` is used for this.
+selects another example application. Field `cleanup` is used for this.
 It is set to a dummy initially, but once the controller starts the
 animation, it is replace with a proper cleanup hook.
 This is then invoked in the cleanup routine of the main selector application
@@ -300,12 +300,12 @@ The rest is pretty straight forward:
 
 ```idris
 export
-adjST : BallsEv -> BallsST -> BallsST
-adjST BallsInit       s = init
-adjST (GotCleanup cu) s = {cleanUp := cu} s
-adjST Run             s = {balls := maybe s.balls initialBalls s.numBalls} s
-adjST (NumIn x)       s = {numBalls := eitherToMaybe x} s
-adjST (Next m)        s = case s.count of
+update : BallsEv -> BallsST -> BallsST
+update BallsInit       s = init
+update (GotCleanup cu) s = {cleanup := cu} s
+update Run             s = {balls := maybe s.balls initialBalls s.numBalls} s
+update (NumIn x)       s = {numBalls := eitherToMaybe x} s
+update (Next m)        s = case s.count of
   0   => { balls $= map (nextBall m), dtime := 0, count := fpsCount } s
   S k => { balls $= map (nextBall m), dtime $= (+m), count := k } s
 ```
@@ -343,7 +343,7 @@ display (Next m)       s =
 The main controller must make sure the animation is started
 by registering an event handler upon initialization.
 Function `Web.MVC.Animate.animate` will respond with a
-cleanup hook, which we put in the `cleanUp` field of the
+cleanup hook, which we put in the `cleanup` field of the
 application state.
 ```
 

--- a/docs/src/Examples/CSS/Performance.idr
+++ b/docs/src/Examples/CSS/Performance.idr
@@ -15,7 +15,7 @@ export
 out : Ref Div
 out = Id "performance_sum"
 
--- text fields where users can enter the number of buttons
+-- text field where users can enter the number of buttons
 export
 natIn : Ref Tag.Input
 natIn = Id "performance_numbuttons"

--- a/docs/src/Examples/Fractals.idr
+++ b/docs/src/Examples/Fractals.idr
@@ -54,11 +54,11 @@ readDelay =
 
 public export
 data FractEv : Type where
-  FractInit : FractEv
-  Iter      : Either String Iterations -> FractEv
-  Redraw    : Either String RedrawDelay -> FractEv
-  Run       : FractEv
-  Inc       : DTime -> FractEv
+  FractInit  : FractEv
+  Iter       : Either String Iterations -> FractEv
+  Redraw     : Either String RedrawDelay -> FractEv
+  Run        : FractEv
+  Inc        : DTime -> FractEv
 
 public export
 record FractST where
@@ -68,11 +68,10 @@ record FractST where
   redrawIn : Maybe RedrawDelay
   redraw   : RedrawDelay
   dtime    : DTime
-  cleanUp  : IO ()
 
 export
 init : FractST
-init = FS [] Nothing Nothing 500 0 (pure ())
+init = FS [] Nothing Nothing 500 0
 
 --------------------------------------------------------------------------------
 --          View
@@ -107,8 +106,9 @@ rotate : List t -> List t
 rotate []     = []
 rotate (h::t) = t ++ [h]
 
+export
 adjST : FractEv -> FractST -> FractST
-adjST FractInit  s = init
+adjST FractInit       s = init
 adjST (Iter x)   s = {itersIn  := eitherToMaybe x} s
 adjST (Redraw x) s = {redrawIn := eitherToMaybe x} s
 adjST (Inc dt)   s =
@@ -137,19 +137,12 @@ displayST s =
   ]
 
 displayEv : FractEv -> Cmd FractEv
-displayEv FractInit  = child exampleDiv content
-displayEv (Iter x)   = validate txtIter x
-displayEv (Redraw x) = validate txtRedraw x
-displayEv Run        = noAction
-displayEv (Inc m)    = noAction
-
-display : FractEv -> FractST -> Cmds FractEv
-display e s = displayEv e :: displayST s
+displayEv FractInit      = child exampleDiv content
+displayEv (Iter x)       = validate txtIter x
+displayEv (Redraw x)     = validate txtRedraw x
+displayEv Run            = noAction
+displayEv (Inc m)        = noAction
 
 export
-runFract : Handler FractEv => Controller FractST FractEv
-runFract FractInit s = do
-  s2   <- runDOM adjST display FractInit s
-  stop <- animate (handle . Inc)
-  pure $ {cleanUp := stop} s2
-runFract e s = runDOM adjST display e s
+display : FractEv -> FractST -> Cmds FractEv
+display e s = displayEv e :: displayST s

--- a/docs/src/Examples/Fractals.idr
+++ b/docs/src/Examples/Fractals.idr
@@ -69,7 +69,7 @@ record FractST where
   redrawIn : Maybe RedrawDelay
   redraw   : RedrawDelay
   dtime    : DTime
-  cleanUp  : IO ()
+  cleanup  : IO ()
 
 export
 init : FractST
@@ -109,17 +109,17 @@ rotate []     = []
 rotate (h::t) = t ++ [h]
 
 export
-adjST : FractEv -> FractST -> FractST
-adjST FractInit       s = init
-adjST (GotCleanup cu) s = {cleanUp := cu} s
-adjST (Iter x)   s = {itersIn  := eitherToMaybe x} s
-adjST (Redraw x) s = {redrawIn := eitherToMaybe x} s
-adjST (Inc dt)   s =
+update : FractEv -> FractST -> FractST
+update FractInit       s = init
+update (GotCleanup cu) s = {cleanup := cu} s
+update (Iter x)   s = {itersIn  := eitherToMaybe x} s
+update (Redraw x) s = {redrawIn := eitherToMaybe x} s
+update (Inc dt)   s =
   let dt2 := s.dtime + dt
    in if cast dt2 >= s.redraw.value
          then {dtime := 0, dragons $= rotate} s
          else {dtime := dt2} s
-adjST Run        s =
+update Run        s =
   fromMaybe s $ do
     i <- s.itersIn
     r <- s.redrawIn

--- a/docs/src/Examples/Main.md
+++ b/docs/src/Examples/Main.md
@@ -25,12 +25,11 @@ the code:
 ```idris
 module Examples.Main
 
-import JS
 import Examples.Selector
 
 covering
 main : IO ()
-main = runJS ui
+main = ui
 ```
 
 This just imports and runs the user interface `ui` defined in module

--- a/docs/src/Examples/Main.md
+++ b/docs/src/Examples/Main.md
@@ -25,11 +25,12 @@ the code:
 ```idris
 module Examples.Main
 
+import JS
 import Examples.Selector
 
 covering
 main : IO ()
-main = runJS $ runController (inject Reset) init ui
+main = runJS ui
 ```
 
 This just imports and runs the user interface `ui` defined in module

--- a/docs/src/Examples/Main.md
+++ b/docs/src/Examples/Main.md
@@ -3,7 +3,7 @@
 Welcome to the dom-mvc tutorial. This as an adaption of the
 example application from the
 [rhone-js](https://github.com/stefan-hoeck/idris2-rhone-js),
-library I used to use for writing interactive single page web
+a library I used to use for writing interactive single page web
 applications in Idris, but which turned out to be overly
 complicated for most tasks. Here, we take a simpler and -
 in my opinion - more satisfying approach.
@@ -33,23 +33,8 @@ main = ui
 ```
 
 This just imports and runs the user interface `ui` defined in module
-`Examples.Selector`. We will have a closer
-look at function `runMVC` once we understand the general
-structure of a dom-mvc project. Function `runJS` comes from
-the [idris2-js](https://github.com/stefan-hoeck/idris2-dom/)
-library: To properly deal with the uncertainties of the
-JavaScript language, the core IO type we use most of the time
-is `JSIO`, which is an alias for `EitherT JSErr IO`, where
-`JSErr` is an error type defined also in idris2-js.
-Function `runJS` breaks out of the `Either` monad by logging
-all errors to the console. This might not be the best solution for a
-real-world application, as the console logs in the browser
-will not be inspected by the average user, but it will do
-for these tutorials.
-
-## What next?
-
-Jump to the [examples selector implementation](Selector.md), to learn about the
+`Examples.Selector` and nothing else. So, in order to really get started,
+jump to the [examples selector implementation](Selector.md), to learn about the
 general structure of an interactive dom-mvc web page.
 
 <!-- vi: filetype=idris2:syntax=markdown

--- a/docs/src/Examples/MathGame.md
+++ b/docs/src/Examples/MathGame.md
@@ -41,17 +41,6 @@ and they can change the language of the user interface:
 data Language = EN | DE
 
 %runElab derive "Language" [Eq]
-
-public export
-data MathEv : Type where
-  Lang     : Language -> MathEv
-  Check    : MathEv
-  MathInit : MathEv
-  Inp      : String -> MathEv
-
-lang : String -> MathEv
-lang "de" = Lang DE
-lang _    = Lang EN
 ```
 
 We also need data types for representing the calculations
@@ -67,6 +56,12 @@ record Calc where
   y  : Integer
   op : Op
 
+record Tile where
+  constructor MkTile
+  posX    : Bits8
+  posY    : Bits8
+  calc    : Calc
+
 result : Calc -> Integer
 result (MkCalc x y Plus)  = x + y
 result (MkCalc x y Minus) = x - y
@@ -78,6 +73,18 @@ dispCalc (MkCalc x y op) = "\{show x} \{dispOp op} \{show y} = "
         dispOp Plus  = "+"
         dispOp Minus = "-"
         dispOp Mult  = "*"
+
+public export
+data MathEv : Type where
+  Lang     : Language -> MathEv
+  Check    : MathEv
+  MathInit : MathEv
+  NewGame  : List Tile -> String -> MathEv
+  Inp      : String -> MathEv
+
+lang : String -> MathEv
+lang "de" = Lang DE
+lang _    = Lang EN
 ```
 
 Next, we need to keep track of the current game state:
@@ -91,12 +98,6 @@ whole game in advance, pairing calculations with the
 corresponding tiles covering the picture.
 
 ```idris
-record Tile where
-  constructor MkTile
-  posX    : Bits8
-  posY    : Bits8
-  calc    : Calc
-
 data Result : Type where
   Ended   : Result
   Correct : Result
@@ -115,7 +116,7 @@ record MathST where
 
 export
 init : MathST
-init = MS EN "" Nothing 0 [] [] ""
+init = MS EN "" Nothing 4 [] [] ""
 
 currentCalc : MathST -> Maybe Calc
 currentCalc gs = case gs.calcs of
@@ -284,12 +285,12 @@ randomTile (px,py) = do
   sortVal <- randomRIO (0, 1000)
   pure (sortVal, MkTile px py c)
 
-randomGame : HasIO io => Language -> io MathST
-randomGame l = do
+randomGame : HasIO io => io MathEv
+randomGame = do
   pic   <- rndSelect pictures
   pairs <- traverse randomTile [| MkPair [0..3] [0..3] |]
   let ts = snd <$> sortBy (comparing fst) pairs
-  pure $ MS l "" Nothing 4 Nil ts pic
+  pure $ NewGame ts pic
 ```
 
 The heart of the application logic is function `checkAnswer`:
@@ -307,11 +308,19 @@ checkAnswer gs = {result := Just Ended} gs
 With the above, updating the application state is very easy:
 
 ```idris
+export
 adjST : MathEv -> MathST -> MathST
-adjST (Lang x) = {lang := x}
-adjST Check    = checkAnswer
-adjST MathInit = id
-adjST (Inp s)  = {answer := s}
+adjST (Lang x)         s = {lang := x} s
+adjST Check            s = checkAnswer s
+adjST MathInit         s = {lang := s.lang} init
+adjST (Inp a)          s = {answer := a} s
+adjST (NewGame ts pic) s =
+  { answer := ""
+  , result := Nothing
+  , wrong  := []
+  , calcs  := ts
+  , pic    := pic
+  } s
 ```
 
 Next, we define the functionality used to display the game state.
@@ -333,24 +342,23 @@ displayST s =
   ]
 
 displayEv : MathEv -> Cmd MathEv
-displayEv (Lang x) = child exampleDiv (content x)
-displayEv Check    = value resultIn ""
-displayEv MathInit = child exampleDiv (content init.lang)
-displayEv (Inp _)  = noAction
+displayEv (Lang x)      = child exampleDiv (content x)
+displayEv Check         = value resultIn ""
+displayEv MathInit      = noAction
+displayEv (Inp _)       = noAction
+displayEv (NewGame _ _) = child exampleDiv (content init.lang)
 
+display' : MathEv -> MathST -> Cmds MathEv
+display' e s = displayEv e :: displayST s
+
+export covering
 display : MathEv -> MathST -> Cmds MathEv
-display e s = displayEv e :: displayST s
+display MathInit s = [ C $ randomGame >>= \e => runMVC adjST display' e s]
+display e        s = display' e s
 ```
 
 The main controller is pretty simple. However, we need to generate
 an random game during initialization, so that slightly complicates things:
-
-```idris
-export
-runMath : Handler MathEv => Controller MathST MathEv
-runMath MathInit s = randomGame s.lang >>= runDOM adjST display MathInit
-runMath e        s = runDOM adjST display e s
-```
 
 <!-- vi: filetype=idris2:syntax=markdown
 -->

--- a/docs/src/Examples/MathGame.md
+++ b/docs/src/Examples/MathGame.md
@@ -330,31 +330,28 @@ top of the picture, display the next calculation, and clear
 the input text field:
 
 ```idris
-displayST : MathST -> Cmds MathEv
+displayST : MathST -> Cmd MathEv
 displayST s =
-  [ disabledM checkBtn $ currentCalc s
-  , disabledM resultIn $ currentCalc s
-  , text calc $ maybe "" dispCalc (currentCalc s)
-  , text out  $ maybe "" (reply s.lang) s.result
-  , attr pic  $ style "background-image : url('\{s.pic}');"
-  , attr out  $ style (fromMaybe "" $ s.result >>= style)
-  , render pic (dispState s)
-  ]
+  batch
+    [ disabledM checkBtn $ currentCalc s
+    , disabledM resultIn $ currentCalc s
+    , text calc $ maybe "" dispCalc (currentCalc s)
+    , text out  $ maybe "" (reply s.lang) s.result
+    , attr pic  $ style "background-image : url('\{s.pic}');"
+    , attr out  $ style (fromMaybe "" $ s.result >>= style)
+    , render pic (dispState s)
+    ]
 
 displayEv : MathEv -> Cmd MathEv
 displayEv (Lang x)      = child exampleDiv (content x)
 displayEv Check         = value resultIn ""
-displayEv MathInit      = noAction
+displayEv MathInit      = child exampleDiv (content EN) <+> cmd randomGame
 displayEv (Inp _)       = noAction
 displayEv (NewGame _ _) = child exampleDiv (content init.lang)
 
-display' : MathEv -> MathST -> Cmds MathEv
-display' e s = displayEv e :: displayST s
-
 export covering
-display : MathEv -> MathST -> Cmds MathEv
-display MathInit s = [ C $ randomGame >>= \e => runMVC adjST display' e s]
-display e        s = display' e s
+display : MathEv -> MathST -> Cmd MathEv
+display e s = displayEv e <+> displayST s
 ```
 
 The main controller is pretty simple. However, we need to generate

--- a/docs/src/Examples/Performance.md
+++ b/docs/src/Examples/Performance.md
@@ -9,7 +9,7 @@ of which can be clicked exactly once before being disabled,
 and the sum of the values clicked will be accumulated and
 displayed at the UI. The sum should be reset when a new set
 of buttons is created and the input field should be cleared
-when the run button is clicked.
+after the run button was clicked.
 
 Since we want to have a look at the performance of this,
 we also include an output field for the time it took to
@@ -69,7 +69,8 @@ data PerfEv : Type where
   NumChanged : Either String NumBtns -> PerfEv
   Reload     : PerfEv
   GotTime    : Integer -> PerfEv
-  Set        : Nat -> PerfEv
+  Clicked    : Nat -> PerfEv
+  ClearNum   : PerfEv
 ```
 
 We also require a function for input validation:
@@ -112,7 +113,7 @@ btnRef n = Id "BTN\{show n}"
 btn : Nat -> Node PerfEv
 btn n =
   button
-    [Id (btnRef n), onClick (Set n), classes [widget,btn,inc]]
+    [Id (btnRef n), onClick (Clicked n), classes [widget,btn,inc]]
     [Text $ show n]
 ```
 
@@ -164,47 +165,67 @@ buttons should be generated. This should also happen if the
 As before, we define several pure functions for updating
 the state and the DOM depending on the current event.
 
-```idris
-dispTime : Maybe NumBtns -> Integer -> String
-dispTime Nothing  ms = "\Loaded no buttons in \{show ms} ms."
-dispTime (Just 1) ms = "\Loaded one button in \{show ms} ms."
-dispTime (Just n) ms = "\Loaded \{show n.value} buttons in \{show ms} ms."
-```
-
 Adjusting the application state is very simple:
 
 ```idris
 export
-adjST : PerfEv -> PerfST -> PerfST
-adjST PerfInit       = const init
-adjST (GotTime _)    = id
-adjST (NumChanged e) = {num := eitherToMaybe e}
-adjST Reload         = {sum := 0}
-adjST (Set k)        = {sum $= (+k)}
+update : PerfEv -> PerfST -> PerfST
+update PerfInit       = const init
+update (GotTime _)    = id
+update (NumChanged e) = {num := eitherToMaybe e}
+update Reload         = {sum := 0}
+update (Clicked k)    = {sum $= (+k)}
+update ClearNum       = {num := Nothing}
 ```
 
 Updating the DOM is not much harder. Here it is very useful that we
 do not use a virtual DOM: Since we don't recreate the whole view on
 every event, we don't have to keep track of the disabled buttons,
-nor do we have redraw thousands of buttons, which would drastically
+nor do we have to redraw thousands of buttons, which would drastically
 slow down the user interface.
 
 ```idris
+dispTime : Maybe NumBtns -> Integer -> String
+dispTime Nothing  ms = "\Loaded no buttons in \{show ms} ms."
+dispTime (Just 1) ms = "\Loaded one button in \{show ms} ms."
+dispTime (Just n) ms = "\Loaded \{show n.value} buttons in \{show ms} ms."
+
 displayST : PerfST -> Cmd PerfEv
 displayST s = batch [disabledM btnRun s.num, show out s.sum]
 
 displayEv : PerfEv -> PerfST -> Cmd PerfEv
 displayEv PerfInit       _ = child exampleDiv content
 displayEv (NumChanged e) _ = validate natIn e
-displayEv (Set k)        _ = disabled (btnRef k) True
+displayEv (Clicked k)    _ = disabled (btnRef k) True
 displayEv (GotTime n)    s = text time (dispTime s.num n)
+displayEv ClearNum       s = value natIn ""
 displayEv Reload         s =
-  maybe noAction (timed GotTime . child buttons . btns) s.num
+  maybe noAction (timed GotTime . child buttons . btns) s.num <+>
+  pure ClearNum
 
 export
 display : PerfEv -> PerfST -> Cmd PerfEv
 display e s = displayEv e s <+> displayST s
 ```
+
+I'd like to look at several of the commands used above. First, note that `Cmd e`
+is a monoid, so we can use semigroup append to combine commands. Function `batch`
+allows us to combine a list of commands. Command `validate` sets a custom
+validation message at an `<input>` field, depending on whether its `Either String x`
+argument is a `Left` or a `Right`.
+
+Function `pure` allows us to synchronously
+fire another event. Here, we only want to clear the user input and disable
+the *run* button again *after* we loaded a new set of buttons. Since the
+state is updated first, we can't clear the `numBtns` field before updating
+the DOM. An alternative would be to use a function of the following type
+instead, which would give us access to the old and new state at the same time:
+
+```haskell
+controller : PerfEv -> PerfST -> (PerfST, Cmd PerfEv)
+```
+
+Both are valid options.
 
 <!-- vi: filetype=idris2:syntax=markdown
 -->

--- a/docs/src/Examples/Performance.md
+++ b/docs/src/Examples/Performance.md
@@ -200,8 +200,7 @@ displayEv (Clicked k)    _ = disabled (btnRef k) True
 displayEv (GotTime n)    s = text time (dispTime s.num n)
 displayEv ClearNum       s = value natIn ""
 displayEv Reload         s =
-  maybe noAction (timed GotTime . child buttons . btns) s.num <+>
-  pure ClearNum
+  cmdIfJust s.num (timed GotTime . child buttons . btns) <+> pure ClearNum
 
 export
 display : PerfEv -> PerfST -> Cmd PerfEv

--- a/docs/src/Examples/Requests.md
+++ b/docs/src/Examples/Requests.md
@@ -53,14 +53,6 @@ data ReqEv : Type where
   Got      : Either HTTPError Quote -> ReqEv
 ```
 
-The state type is even trivial: There is no state of interest, and I'm just
-using a placeholder to align it with the other example apps.
-
-```idris
-public export
-data ReqST = RS
-```
-
 ## View
 
 The view just holds a button and some space for printing
@@ -105,17 +97,14 @@ Finally, the controller: The only new part is where we send a
 HTTP request when event `GetQuote` occurs:
 
 ```idris
-display : ReqEv -> ReqST -> Cmds ReqEv
-display ReqInit  s = [child exampleDiv content]
-display GetQuote s = [getJSON "https://elm-lang.org/api/random-quotes" Got]
-display (Got x)  s =
+export
+display : ReqEv -> Cmds ReqEv
+display ReqInit  = [child exampleDiv content]
+display GetQuote = [getJSON "https://elm-lang.org/api/random-quotes" Got]
+display (Got x)  =
   [ children quoteInfo (dispResult x)
   , text quote $ either (const "") quote x
   ]
-
-export
-runReq : Handler ReqEv => Controller ReqST ReqEv
-runReq = runDOM (const id) display
 ```
 
 <!-- vi: filetype=idris2:syntax=markdown

--- a/docs/src/Examples/Requests.md
+++ b/docs/src/Examples/Requests.md
@@ -28,7 +28,11 @@ import Web.MVC.Http
 When sending a request to the server at "https://elm-lang.org/api/random-quotes",
 the response is a quote plus some information encoded in a JSON object.
 We therefore first need to decode the JSON object in question and
-store its content in a record type:
+store its content in a record type. Interface `FromJSON` from the *json-simple*
+library is used for decoding JSON objects. It can be derived automatically
+via elaborator reflection for regular data types (if you are more interested
+in this topic, the [elab-util](https://github.com/stefan-hoeck/idris2-elab-util)
+library comes with its own lengthy tutorial).
 
 ```idris
 public export
@@ -42,8 +46,8 @@ record Quote where
 %runElab derive "Quote" [Show,Eq,FromJSON,ToJSON]
 ```
 
-Our even type is very basic: An event to initialize the page,
-one to send a new request, and one holding the server's response:
+Our event type is very basic: An event to initialize the page,
+one to start a new request, and one to hold the server's response:
 
 ```idris
 public export

--- a/docs/src/Examples/Requests.md
+++ b/docs/src/Examples/Requests.md
@@ -98,13 +98,14 @@ HTTP request when event `GetQuote` occurs:
 
 ```idris
 export
-display : ReqEv -> Cmds ReqEv
-display ReqInit  = [child exampleDiv content]
-display GetQuote = [getJSON "https://elm-lang.org/api/random-quotes" Got]
+display : ReqEv -> Cmd ReqEv
+display ReqInit  = child exampleDiv content
+display GetQuote = getJSON "https://elm-lang.org/api/random-quotes" Got
 display (Got x)  =
-  [ children quoteInfo (dispResult x)
-  , text quote $ either (const "") quote x
-  ]
+  batch
+    [ children quoteInfo (dispResult x)
+    , text quote $ either (const "") quote x
+    ]
 ```
 
 <!-- vi: filetype=idris2:syntax=markdown

--- a/docs/src/Examples/Reset.md
+++ b/docs/src/Examples/Reset.md
@@ -109,13 +109,14 @@ the necessary updates to the DOM, that are required on
 almost every event:
 
 ```idris
-displayST : Int8 -> Cmds ResetEv
+displayST : Int8 -> Cmd ResetEv
 displayST n =
-  [ disabled btnDec   (n <= -10)
-  , disabled btnInc   (n >= 10)
-  , disabled btnReset (n == 0)
-  , show out n
-  ]
+  batch
+    [ disabled btnDec   (n <= -10)
+    , disabled btnInc   (n >= 10)
+    , disabled btnReset (n == 0)
+    , show out n
+    ]
 ```
 
 Third, one for updating the DOM based on the current event.
@@ -126,8 +127,8 @@ on the initializing event:
 
 ```idris
 export
-display : ResetEv -> Int8 -> Cmds ResetEv
-display ResetInit n = child exampleDiv content :: displayST n
+display : ResetEv -> Int8 -> Cmd ResetEv
+display ResetInit n = child exampleDiv content <+> displayST n
 display (Mod f)   n = displayST n
 ```
 
@@ -137,6 +138,35 @@ own `Cmd` in case some functionality is missing.
 A `Cmd e` is a wrapper around `Handler e => JSIO ()`, which
 allows us to implement updates to the DOM which register new
 event handlers.
+
+Here is a non-comprehensive list of predefined `Cmd`s:
+
+* `children`: Replaces a node's child nodes with a new list of nodes.
+* `child`: Replaces a node's child nodes with a single new node.
+* `text`: Replaces a node's child nodes with a text node.
+* `show`: Like `text` but uses `show` on its argument to create a string
+  to display.
+* `raw`: Replaces a node's child nodes with new nodes generated from the
+  string argument containing raw HTML.
+* `style`: Replaces a `<style>` node's content if a set of new CSS rules.
+* `append`: Appends a node to the list of children of another node.
+* `prepend`: Prepends a node to the list of children of another node.
+* `before`: Puts a node before another in a list of child nodes.
+* `after`: Puts a node after another in a list child nodes.
+* `replace`: Replace a whole node with another one.
+* `remove` : Removes a node and all its children from the DOM.
+* `validityMsg`: Set a custom validity message at an element.
+* `validate`: Set a custom validity message at an element based
+  on an `Either String a`.
+* `attr`: Sets a single attribute at a node. This could also be a new
+  event.
+* `render` : Render a `Scene` at a canvas element.
+* `value` : Change the value of an `<input>` or similar element.
+* `focus` : Focus the given element. Useful when a new `<input>` field
+  or button has just been created.
+
+As we will see in later parts of the tutorial, it is quite straight forward
+to create ones own `Cmd e` values.
 
 <!-- vi: filetype=idris2:syntax=markdown
 -->

--- a/docs/src/Examples/Reset.md
+++ b/docs/src/Examples/Reset.md
@@ -98,6 +98,7 @@ application: First, one for adjusting the application state
 according to the current event.
 
 ```idris
+export
 adjST : ResetEv -> Int8 -> Int8
 adjST ResetInit n = 0
 adjST (Mod f) n = f n
@@ -124,6 +125,7 @@ on specific occasions. Here, we completely redraw the app
 on the initializing event:
 
 ```idris
+export
 display : ResetEv -> Int8 -> Cmds ResetEv
 display ResetInit n = child exampleDiv content :: displayST n
 display (Mod f)   n = displayST n
@@ -135,15 +137,6 @@ own `Cmd` in case some functionality is missing.
 A `Cmd e` is a wrapper around `Handler e => JSIO ()`, which
 allows us to implement updates to the DOM which register new
 event handlers.
-
-Finally, we define the application controller by just passing
-functions `adjST` and `display` to utility `Web.MVC.Run.runDOM`.
-
-```idris
-export
-runReset : Handler ResetEv => Controller Int8 ResetEv
-runReset = runDOM adjST display
-```
 
 <!-- vi: filetype=idris2:syntax=markdown
 -->

--- a/docs/src/Examples/Reset.md
+++ b/docs/src/Examples/Reset.md
@@ -53,7 +53,7 @@ Next, we need to identify the dynamic components
 of our application whose behavior or appearance will
 change depending on the current state.
 There are four of them: The buttons for increasing and decreasing
-the counter, which will be disabled if the value gets to
+the counter, which will be disabled if the value gets too
 small or too big, the reset button, which will be disabled
 if the counter is at zero, and the div element where we will output
 the current count. Again, the corresponding `Ref t`s
@@ -91,22 +91,42 @@ content =
       ]
 ```
 
+Node, that unlike in the Elm Architecture, we did not display the
+whole model in `content`, although it would certainly have been
+possible to do so. This is a matter of preference and sometimes a
+matter of performance.
+
+Personally, I prefer having a separate function for updating
+the dynamic parts of the view, depending on the current event
+and model. This makes the things that change on certain events
+stand out somewhat more at the cost of some more verbose code.
+
 ## Controller
 
 We typically define three pure functions for controlling the
 application: First, one for adjusting the application state
-according to the current event.
+according to the current event. We call this one `update` as
+in Elm:
 
 ```idris
 export
-adjST : ResetEv -> Int8 -> Int8
-adjST ResetInit n = 0
-adjST (Mod f) n = f n
+update : ResetEv -> Int8 -> Int8
+update ResetInit n = 0
+update (Mod f) n = f n
 ```
 
-Second, one for displaying the current state. This lists
-the necessary updates to the DOM, that are required on
-almost every event:
+Second, one for displaying the current state and possibly causing
+other side effects. This lists - amongst other things - the necessary
+updates to the DOM. Some of these effects might setup new event sources,
+by setting up new components in the DOM, starting an animation, or sending
+a HTTP request. Therefore, the return type is not `IO` or `JSIO` but
+`Cmd`. I tend to call these functions `display`, although the can do
+more than just displaying stuff as we will see in later parts of the
+tutorial.
+
+Here is a function that always updates the view according to
+the current state. It will define whether the buttons are enabled or not,
+and it will print the state of the counter:
 
 ```idris
 displayST : Int8 -> Cmd ResetEv
@@ -119,11 +139,10 @@ displayST n =
     ]
 ```
 
-Third, one for updating the DOM based on the current event.
-This includes updates that may take some time to run or
-may interrupt user input, so we only want them to occur
-on specific occasions. Here, we completely redraw the app
-on the initializing event:
+And here is the main `display` function for acting on the
+current event and updated state (the main controller `runMVC`
+we use in our main application always updates the state first,
+before using it to compute the command):
 
 ```idris
 export
@@ -133,11 +152,11 @@ display (Mod f)   n = displayST n
 ```
 
 All the `Cmd` actions used above are defined in module
-`Web.MVC.Run`. It is pretty straight forward to define your
+`Web.MVC.View`. It is pretty straight forward to define your
 own `Cmd` in case some functionality is missing.
-A `Cmd e` is a wrapper around `Handler e => JSIO ()`, which
-allows us to implement updates to the DOM which register new
-event handlers.
+A `Cmd e` is a wrapper around `(handler : e -> JSIO ()) -> JSIO ()`, where
+the `handler` argument can be used as an event listener and invoked
+for firing new events synchronously or asynchronously.
 
 Here is a non-comprehensive list of predefined `Cmd`s:
 

--- a/dom-mvc.ipkg
+++ b/dom-mvc.ipkg
@@ -9,7 +9,9 @@ depends    = base      >= 0.6.0
            , refined
            , tailrec
 
-modules    = Text.CSS
+modules    = Data.Queue
+
+           , Text.CSS
            , Text.CSS.Angle
            , Text.CSS.Color
            , Text.CSS.Declaration
@@ -35,9 +37,10 @@ modules    = Text.CSS
            , Web.MVC
            , Web.MVC.Animate
            , Web.MVC.Cmd
-           , Web.MVC.Output
            , Web.MVC.Event
            , Web.MVC.Http
+           , Web.MVC.Util
+           , Web.MVC.View
 
            , Web.MVC.Canvas
            , Web.MVC.Canvas.Angle

--- a/src/Data/Queue.idr
+++ b/src/Data/Queue.idr
@@ -1,0 +1,125 @@
+module Data.Queue
+
+import Derive.Prelude
+
+%language ElabReflection
+
+%default total
+
+||| An immutable first-in first-out structure with amortized
+||| O(1) enqueu and dequeue operations.
+|||
+||| Currently, this is neither length-indexed, nor does it
+||| keep track of its size internally. Time will tell, whether
+||| we some of this additional stuff.
+export
+record Queue a where
+  constructor Q
+  front : List a
+  back  : SnocList a
+
+||| The empty queue. O(1)
+export %inline
+empty : Queue a
+empty = Q [] [<]
+
+||| Converts a list to a queue, keeping the order of
+||| elements. O(1)
+export %inline
+fromList : List a -> Queue a
+fromList vs = Q vs [<]
+
+||| Converts a `SnocList` to a queue, keeping the order of
+||| elements. O(1)
+export %inline
+fromSnocList : SnocList a -> Queue a
+fromSnocList sv = Q [] sv
+
+||| Converts a `Queue` to a `SnocList`, keeping the order
+||| of elements. O(n)
+export %inline
+toSnocList : Queue a -> SnocList a
+toSnocList (Q f b) = b <>< f
+
+||| Append a value at the back of the queue. O(1)
+export
+enqueue : a -> Queue a -> Queue a
+enqueue v (Q f b) = Q f (b :< v)
+
+||| Take a value from the front of the queue.
+|||
+||| In case of the front being empty, this transfers
+||| the back to the front, which runs in O(n). However,
+||| every element in the queue is thus shifted at most
+||| once before being dequeud, so this runs in amortized
+||| O(1).
+export
+dequeue : Queue a -> Maybe (a, Queue a)
+dequeue (Q (f :: front) back) = Just (f, Q front back)
+dequeue (Q [] back)           = case back <>> [] of
+  h :: t => Just (h, Q t [<])
+  []     => Nothing
+
+||| We can append an element to our `Queue`, making it the new
+||| "oldest" element. O(1)
+|||
+||| This is against the typical use case for a FIFO data
+||| structure, but it allows us to conveniently implement
+||| `peekOldest`.
+export
+append : a -> Queue a -> Queue a
+append x (Q f b) = Q f (b :< x)
+
+||| Return the last element of the queue, plus the unmodified
+||| queue.
+|||
+||| Note: `peekQueue` might involve a rearrangement of the elements
+|||       just like `dequeue`. In order to keep our amortized O(1)
+|||       runtime behavior, the newly arranged queue should be used
+|||       henceforth.
+export
+peekOldest : Queue a -> Maybe (a, Queue a)
+peekOldest q = case dequeue q of
+  Just (v,q') => Just (v, append v q')
+  Nothing     => Nothing
+
+||| Appends two `Queues`. O(m + n)
+export
+(++) : Queue a -> Queue a -> Queue a
+Q f1 b1 ++ Q f2 b2 = Q (b1 <>> f1) (b2 <>< f2)
+
+||| Returns the length of the `Queue`. O(n).
+export
+length : Queue a -> Nat
+length (Q f b) = length f + length b
+
+--------------------------------------------------------------------------------
+--          Interfaces
+--------------------------------------------------------------------------------
+
+%runElab derive "Queue" [Show,Eq]
+
+export %inline
+Semigroup (Queue a) where
+  (<+>) = (++)
+
+export %inline
+Monoid (Queue a) where
+  neutral = empty
+
+export
+Functor Queue where
+  map f (Q front back) = Q (map f front) (map f back)
+
+export
+Foldable Queue where
+  toList (Q f b) = b <>> f
+  foldr f acc = foldr f acc . toSnocList
+  foldl f acc = foldl f acc . toList
+  foldMap f = foldMap f . toList
+  foldlM f acc = foldlM f acc . toList
+  null (Q f b) = null f || null b
+
+export
+Traversable Queue where
+  traverse f (Q front back) = [| Q (traverse f front) (traverse f back) |]

--- a/src/Web/MVC.idr
+++ b/src/Web/MVC.idr
@@ -1,90 +1,76 @@
 module Web.MVC
 
 import Data.IORef
-import Data.List.Quantifiers.Extra
+import Data.Queue
 
 import public JS
 import public Web.MVC.Cmd
+import public Web.MVC.View
 import public Text.HTML
-
-||| A controller is an effectful computation for
-||| updating a displaying some application state based
-||| on an event type e.
-|||
-||| When dealing with a heterogeneous sum of possible events,
-||| as is encouraged here for writing applications with several
-||| more or less unrelated event sources, it is convenient
-||| to wrap one controller for handling each event in a
-||| heterogeneous list from `Data.List.Quantifiers`. Therefore,
-||| the state type comes first in this alias, and the event
-||| type comes second, even though in actual controller function
-||| it's the other way round.
-public export
-0 Controller : Type -> Type -> Type
-Controller s e = e -> s -> JSIO s
-
-||| Given a heterogeneous list of controllers, we can react
-||| on the events in a heterogeneous sum.
-export
-controlMany : All (Controller s) es -> Controller s (HSum es)
-controlMany cs evs s = collapse' $ hzipWith (\f,e => f e s) cs evs
 
 ||| Run (a part of) an interactive web page firing events of type
 ||| `e` and holding state of type `s`.
-|||
-||| The controller is used for updating and displaying the new
-||| application state upon an event, an effectful computation that
-||| might include the registering of new events in the UI, for
-||| which the controller requires and auto implicit argument of
-||| type `Handler e`.
-|||
-||| Important note: Passing the event handler explicitly to the
-||| controller might lead to it being  invoke with an event from
-||| within an event handling step. This could potentially lead to
-||| an infinite loop and is the reason why this function is
-||| not total. So, make sure to only register the event handler
-||| as an event listener or similar at components that will
-||| invoke it asynchrounously.
 export covering
 runController :
      {0 e,s  : Type}
+  -> (ctrl   : e -> s -> (s, Cmd e))
+  -> (onErr  : JSErr -> IO ())
   -> (initEv : e)
   -> (initST : s)
-  -> (ctrl   : Handler e => Controller s e)
-  -> JSIO ()
-runController initEv initST ctrl = do
-  ref <- newIORef initST
+  -> IO ()
+runController ctrl onErr initEv initST = Prelude.do
+  state <- newIORef initST
+  flag  <- newIORef False
+  queue <- newIORef $ Queue.empty {a = e}
 
-  let covering handler : Handler e
-      handler = H $ \ev => do
-        stOld <- readIORef ref
-        stNew <- ctrl @{handler} ev stOld
-        writeIORef ref stNew
+  let covering handle : e -> IO ()
+      handle ev = Prelude.do
 
-  handler.handle_ initEv
+        -- Enqueue synchronously fired events if we are already handling
+        -- an event
+        False <- readIORef flag | True => modifyIORef queue (enqueue ev)
 
-||| Run an interactive web page firing events of type
-||| `e` and holding state of type `s`.
-|||
-||| This is a simplified version of `runController` for applications
-||| that do not require additional side effects when updating the
-||| state.
-|||
-||| More complex setups might include random number generation or
-||| setting up and breaking down scarce resources such as animations.
-||| These should be handled with `runController`.
-|||
-||| @ update  : Update the state according to the current event.
-||| @ display : Update the view according to the current event and
-|||             *updated* state.
-||| @initEv   : Event used for initializing the user interface
-||| @initST   : Initial application state.
-export covering %inline
+        -- Start handing the event and prevent others from currently
+        -- being handled
+        writeIORef flag True
+
+        -- read current application state
+        stOld <- readIORef state
+
+        -- compute new application state and the command to run
+        let (stNew, cmd) := ctrl ev stOld
+
+        -- update application state
+        writeIORef state stNew
+
+        -- run the command by invoking it with this very event handler
+        -- the command might fire one or more events synchronously. these
+        -- will be enqueued and processed in a moment.
+        ei <- runEitherT (run cmd (liftIO . handle))
+
+        case ei of
+          Left err => onErr err
+          Right () => pure ()
+
+        -- we are do with handling the current event so we set the flag
+        -- back to false.
+        writeIORef flag False
+
+        -- we are now going to process the next enqueued command (if any)
+        Just (ev2,q) <- dequeue <$> readIORef queue | Nothing => pure ()
+        writeIORef queue q
+        handle ev2
+
+  handle initEv
+
+export covering
 runMVC :
-     {0 e,s  : Type}
+     {0 e,s   : Type}
   -> (update  : e -> s -> s)
-  -> (display : e -> s -> Cmds e)
+  -> (display : e -> s -> Cmd e)
+  -> (onErr   : JSErr -> IO ())
   -> (initEv  : e)
   -> (initST  : s)
-  -> JSIO ()
-runMVC update display ev st = runController ev st (runDOM update display)
+  -> IO ()
+runMVC upd disp onErr =
+  runController (\ev,st => let st2 := upd ev st in (st2, disp ev st2)) onErr

--- a/src/Web/MVC/Canvas.idr
+++ b/src/Web/MVC/Canvas.idr
@@ -4,7 +4,7 @@ import JS
 import Text.HTML.Ref
 import Text.HTML.Tag
 import Web.Html
-import Web.MVC.Output
+import Web.MVC.Util
 
 import public Web.MVC.Canvas.Angle
 import public Web.MVC.Canvas.Scene

--- a/src/Web/MVC/Canvas.idr
+++ b/src/Web/MVC/Canvas.idr
@@ -38,6 +38,7 @@ context2D canvas = do
     Just c  => pure c
     Nothing => throwError $ Caught "Web.MVC.Canvas.context2d: No rendering context for canvas"
 
+||| Render a seen in a canvas in the DOM.
 export
 render : Ref Canvas -> (CanvasDims -> Scene) -> JSIO ()
 render ref scene = do

--- a/src/Web/MVC/Cmd.idr
+++ b/src/Web/MVC/Cmd.idr
@@ -1,398 +1,71 @@
 module Web.MVC.Cmd
 
 import Control.Monad.Either.Extra
-import Data.Contravariant
-import Data.List.Quantifiers.Extra
-import Data.Either
-import Data.Maybe
-import Data.String
 import JS
-import Text.CSS
-import Text.HTML
-import Web.Dom
-import Web.Html
-import Web.MVC.Canvas
-import Web.MVC.Event
-import Web.MVC.Output
 
 %default total
 
 --------------------------------------------------------------------------------
---          Event Handler
+--          Commands
 --------------------------------------------------------------------------------
 
-||| Type alias for an event handler
-public export
-record Handler (e : Type) where
-  [noHints]
-  constructor H
-  handle_ : e -> JSIO ()
-
-export %inline
-Contravariant Handler where
-  contramap f (H h) = H (h . f)
-
-export
-cmapIO : {0 a,b : _} -> (a -> JSIO b) -> Handler b -> Handler a
-cmapIO f (H g) = H $ f >=> g
-
-export %inline
-handle : Handler e => e -> JSIO ()
-handle = handle_ %search
-
-export %inline
-inject : Has e es => Handler (HSum es) -> Handler e
-inject (H h) = H (h . inject)
-
-export
-Semigroup (Handler e) where
-  H f <+> H g = H $ \v => f v >> g v
-
-export
-Monoid (Handler e) where
-  neutral = H $ \_ => pure ()
-
---------------------------------------------------------------------------------
---          Registering Events
---------------------------------------------------------------------------------
-
-parameters {0 e    : Type}
-           {auto h : Handler e}
-
-  ||| Low level method for registering `DOMEvents` at
-  ||| HTML elements.
-  |||
-  ||| Use this, for instance, to register `DOMEvents` at
-  ||| a HTMLElement of a static document.
-  export
-  registerDOMEvent :
-       (preventDefault, stopPropagation : Bool)
-    -> EventTarget
-    -> DOMEvent e
-    -> JSIO ()
-  registerDOMEvent prev stop el de = case de of
-    Input f      => inst "input" inputInfo f
-    Change f     => inst "change" changeInfo f
-    Click f      => inst "click" mouseInfo f
-    DblClick f   => inst "dblclick" mouseInfo f
-    KeyDown f    => inst "keydown" keyInfo f
-    KeyUp f      => inst "keyup" keyInfo f
-    Blur v       => inst "blur" {t = Event} (const $ pure v) Just
-    Focus v      => inst "focus" {t = Event} (const $ pure v) Just
-    MouseDown f  => inst "mousedown" mouseInfo f
-    MouseUp f    => inst "mouseup" mouseInfo f
-    MouseEnter f => inst "mouseenter" mouseInfo f
-    MouseLeave f => inst "mouseleave" mouseInfo f
-    MouseOver f  => inst "mouseover" mouseInfo f
-    MouseOut f   => inst "mouseout" mouseInfo f
-    MouseMove f  => inst "mousemove" mouseInfo f
-    HashChange v => inst "hashchange" {t = Event} (const $ pure v) Just
-    Wheel f      => inst "wheel" wheelInfo f
-
-    where
-      inst :
-           {0 t,b : _}
-        -> {auto c : SafeCast t}
-        -> String
-        -> (t -> JSIO b)
-        -> (b -> Maybe e)
-        -> JSIO ()
-      inst {t} s conv f = do
-        c <- callback {cb = EventListener} $ \e => do
-          canc <- cancelable e
-          bubl <- bubbles e
-          when (canc && prev) (preventDefault e)
-          when (bubl && stop) (stopPropagation e)
-          va <- tryCast_ t "Web.MVC.Cmd.inst" e
-          conv va >>= maybe (pure ()) handle . f
-
-        addEventListener el s (Just c)
-
-  export
-  setAttribute : Element -> Attribute t e -> JSIO ()
-  setAttribute el (Id (Id value))   = setAttribute el "id" value
-  setAttribute el (Str name value)  = setAttribute el name value
-  setAttribute el (Bool name value) = case value of
-    True  => setAttribute el name ""
-    False => removeAttribute el name
-  setAttribute el (Event_ prev stop ev) = registerDOMEvent prev stop(up el) ev
-  setAttribute el Empty      = pure ()
-
-
---------------------------------------------------------------------------------
---          Node Preparation
---------------------------------------------------------------------------------
-
-  addNodes :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ParentNode (Types t)}
-    -> (doc      : Document)
-    -> (parent   : t)
-    -> (nodes    : List (Node e))
-    -> JSIO ()
-
-  addNode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ParentNode (Types t)}
-    -> (doc      : Document)
-    -> (parent   : t)
-    -> (node     : Node e)
-    -> JSIO ()
-  addNode doc p (El {tag} _ xs ys) = do
-    n <- createElement doc tag
-    append p [inject $ n :> Node]
-    addNodes doc n ys
-    traverseList_ (setAttribute n) xs
-
-  addNode doc p (Raw str) = do
-    el <- createElement doc "template"
-    Just temp <- pure (castTo HTMLTemplateElement el) | Nothing => pure ()
-    innerHTML temp .= str
-    c         <- content temp
-    append p [inject $ c :> Node]
-
-  addNode doc p (Text str) = append p [inject str]
-
-  addNode doc p Empty      = pure ()
-
-  addNodes doc p = assert_total $ traverseList_ (addNode doc p)
-
+||| A `Cmd` (abbreviation of "command") is a (typically effectful) computation
+||| sending its result to an event handler.
 public export
 record Cmd (e : Type) where
   constructor C
-  run : Handler e => JSIO ()
+  run : (e -> JSIO ()) -> JSIO ()
 
 export %inline
 Functor Cmd where
-  map f (C run) = C $ run @{contramap f %search}
+  map f (C run) = C $ run . (. f)
+
+bind : {0 a,b : _} -> Cmd a -> (a -> Cmd b) -> Cmd b
+bind (C g) f = C $ \h => g $ \va => run (f va) h
+
+export %inline
+Applicative Cmd where
+  pure v = C $ \h => h v
+  cf <*> cv = bind cf (<$> cv)
+
+export %inline
+Monad Cmd where
+  (>>=) = bind
 
 export
 Semigroup (Cmd e) where
-  C f <+> C g = C $ f >> g
+  C f <+> C g = C $ \h => f h >> g h
 
-export
+export %inline
 Monoid (Cmd e) where
-  neutral = C $ pure ()
+  neutral = C . const $ pure ()
 
+||| Wrap a batch of commands in a single command by
+||| running them sequentially.
+export
+batch : List (Cmd e) -> Cmd e
+batch cs = C $ \h => traverseList_ (`run` h) cs
+
+||| Wrap an effectful computation in a command.
 export %inline
-mapCmdIO : {0 a,b : _} -> (a -> JSIO b) -> Cmd a -> Cmd b
-mapCmdIO f (C run) = C $ run @{cmapIO f %search}
+cmd : JSIO e -> Cmd e
+cmd v = C (v >>=)
 
-public export
-0 Cmds : Type -> Type
-Cmds = List . Cmd
-
+||| Wrap an effectful computation in a command.
 export %inline
-mapCmds : {0 a,b : _} -> (a -> b) -> Cmds a -> Cmds b
-mapCmds = map . map
+cmd_ : JSIO () -> Cmd e
+cmd_ v = C $ const v
 
-export %inline
-mapCmdsIO : {0 a,b : _} -> (a -> JSIO b) -> Cmds a -> Cmds b
-mapCmdsIO = map . mapCmdIO
-
+||| A command that produces no event.
 export %inline
 noAction : Cmd e
-noAction = C (pure ())
-
-setupNodes :
-     (Element -> DocumentFragment -> JSIO ())
-  -> Ref t
-  -> List (Node e)
-  -> Cmd e
-setupNodes adj r ns = C $ do
-  doc  <- document
-  elem <- castElementByRef {t = Element} r
-  df   <- createDocumentFragment doc
-  addNodes doc df ns
-  adj elem df
-
-%inline
-setupNode :
-     (Element -> DocumentFragment -> JSIO ())
-  -> Ref t
-  -> Node e
-  -> Cmd e
-setupNode adj r n = setupNodes adj r [n]
-
-||| Execute several DOM update instructions
-export %inline
-updateDOM : Handler e => Cmds e -> JSIO ()
-updateDOM = traverseList_ (\x => x.run)
-
-||| Sets up the reactive behavior of the given `Node`s and
-||| inserts them as the children of the given target.
-export %inline
-children : Ref t -> List (Node e) -> Cmd e
-children = setupNodes replaceChildren
-
-||| Sets up the reactive behavior of the given `Node` and
-||| inserts it as the only child of the given target.
-export %inline
-child : Ref t -> Node e -> Cmd e
-child = setupNode replaceChildren
-
-||| Replaces the given node's children with a text node
-||| displaying the given string.
-export %inline
-text : Ref t -> String -> Cmd e
-text r = child r . Text
-
-||| Replaces the given node's children with a text node
-||| showing the given value.
-export %inline
-show : Show b => Ref t -> b -> Cmd e
-show r = text r . show
-
-||| Replaces the given node's children with the raw
-||| HTML passed as a string argument.
-export %inline
-raw : Ref t -> String -> Cmd e
-raw r = child r . Raw
-
-||| Replaces the given `<style>` node's CSS rules.
-export
-style : Ref Tag.Style -> List (Rule 1) -> Cmd e
-style r rules =
-  let str := fastUnlines $ map interpolate rules
-   in raw r str
-
-||| Sets up the reactive behavior of the given `Node`s and
-||| inserts them after the given child node.
-export %inline
-afterMany : Ref t -> List (Node e) -> Cmd e
-afterMany = setupNodes afterDF
-
-||| Sets up the reactive behavior of the given `Node` and
-||| inserts it after the given child node.
-export %inline
-after : Ref t -> Node e -> Cmd e
-after = setupNode afterDF
-
-||| Sets up the reactive behavior of the given `Node`s and
-||| inserts them before the given child node.
-export %inline
-beforeMany : Ref t -> List (Node e) -> Cmd e
-beforeMany = setupNodes beforeDF
-
-||| Sets up the reactive behavior of the given `Node` and
-||| inserts it before the given child node.
-export %inline
-before : Ref t -> Node e -> Cmd e
-before = setupNode beforeDF
-
-||| Sets up the reactive behavior of the given `Node`s and
-||| appends them to the given element's list of children
-export %inline
-appendMany : Ref t -> List (Node e) -> Cmd e
-appendMany = setupNodes appendDF
-
-||| Sets up the reactive behavior of the given `Node` and
-||| appends it to the given element's list of children
-export %inline
-append : Ref t -> Node e -> Cmd e
-append = setupNode appendDF
-
-||| Sets up the reactive behavior of the given `Node`s and
-||| prepends them to the given element's list of children
-export %inline
-prependMany : Ref t -> List (Node e) -> Cmd e
-prependMany = setupNodes prependDF
-
-||| Sets up the reactive behavior of the given `Node` and
-||| prepends it to the given element's list of children
-export %inline
-prepend : Ref t -> Node e -> Cmd e
-prepend = setupNode prependDF
-
-||| Sets up the reactive behavior of the given `Node`s and
-||| replaces the given element.
-export %inline
-replaceMany : Ref t -> List (Node e) -> Cmd e
-replaceMany = setupNodes replaceDF
-
-||| Sets up the reactive behavior of the given `Node` and
-||| replaces the given element.
-export %inline
-replace : Ref t -> Node e -> Cmd e
-replace = setupNode replaceDF
-
-||| Sets a custom validity message at the given node.
-export %inline
-validityMsg : Ref t -> ValidityTag t => String -> Cmd e
-validityMsg r s = C $ setValidityMessage r s
-
-||| Sets or unsets a custom validity message at the given node.
-export
-validate : Ref t -> ValidityTag t => Either String b -> Cmd e
-validate r (Left s)  = validityMsg r s
-validate r (Right s) = validityMsg r ""
-
-||| Sets an attribute at the given node.
-export
-attr : Ref t -> Attribute t e -> Cmd e
-attr r a = C $ castElementByRef r >>= \el => setAttribute el a
-
-||| Sets the `disabled` attribute of the given element
-export %inline
-disabled : Ref t -> Bool -> Cmd e
-disabled r = attr r . disabled
-
-||| Sets the `disabled` attribute of the given element
-||| if the given values is a `Left`.
-|||
-||| This is useful for disabling components such as buttons
-||| in the UI in case of invalid user input.
-export %inline
-disabledE : {0 a,b : _} -> Ref t -> Either a b -> Cmd e
-disabledE r = disabled r . isLeft
-
-||| Sets the `disabled` attribute of the given element
-||| if the given values is a `Nothing`.
-|||
-||| This is useful for disabling components such as buttons
-||| in the UI in case of invalid user input.
-export %inline
-disabledM : {0 a : _} -> Ref t -> Maybe a -> Cmd e
-disabledM r = disabled r . isNothing
-
-||| Removes the given element from the DOM.
-export
-remove : Ref t -> Cmd e
-remove r = C (castElementByRef {t = Element} r >>= remove)
-
-||| Sets the `value` attribute of the given element.
-export %inline
-value : Ref t -> ValueTag t => String -> Cmd e
-value r s = C (setValue r s)
-
-||| Renders a scene at a canvas element
-export %inline
-renderWithDims : Ref Tag.Canvas -> (CanvasDims -> Scene) -> Cmd e
-renderWithDims r s = C (render r s)
-
-||| Renders a scene at a canvas element
-export %inline
-render : Ref Tag.Canvas -> Scene -> Cmd e
-render r = renderWithDims r . const
-
-||| Focus the given HTMLElemet
-export %inline
-focus : Ref t -> Cmd e
-focus r = C (castElementByRef {t = HTMLElement} r >>= HTMLOrSVGElement.focus)
+noAction = neutral
 
 export
 updateIf : Bool -> Lazy (Cmd e) -> Cmd e
 updateIf True  u = u
 updateIf False _ = noAction
 
-export
-runDOM :
-     {auto h : Handler e2}
-  -> (adjST   : e -> s -> s)
-  -> (display : e -> s -> Cmds e2)
-  -> (event   : e)
-  -> (state   : s)
-  -> JSIO s
-runDOM adjST display event state =
-  let st2 := adjST event state
-   in updateDOM (display event st2) $> st2
+export %inline
+HasIO Cmd where
+  liftIO = cmd . liftIO

--- a/src/Web/MVC/Cmd.idr
+++ b/src/Web/MVC/Cmd.idr
@@ -32,6 +32,10 @@ export %inline
 Contravariant Handler where
   contramap f (H h) = H (h . f)
 
+export
+cmapIO : {0 a,b : _} -> (a -> JSIO b) -> Handler b -> Handler a
+cmapIO f (H g) = H $ f >=> g
+
 export %inline
 handle : Handler e => e -> JSIO ()
 handle = handle_ %search
@@ -170,9 +174,21 @@ export
 Monoid (Cmd e) where
   neutral = C $ pure ()
 
+export %inline
+mapCmdIO : {0 a,b : _} -> (a -> JSIO b) -> Cmd a -> Cmd b
+mapCmdIO f (C run) = C $ run @{cmapIO f %search}
+
 public export
 0 Cmds : Type -> Type
 Cmds = List . Cmd
+
+export %inline
+mapCmds : {0 a,b : _} -> (a -> b) -> Cmds a -> Cmds b
+mapCmds = map . map
+
+export %inline
+mapCmdsIO : {0 a,b : _} -> (a -> JSIO b) -> Cmds a -> Cmds b
+mapCmdsIO = map . mapCmdIO
 
 export %inline
 noAction : Cmd e

--- a/src/Web/MVC/Cmd.idr
+++ b/src/Web/MVC/Cmd.idr
@@ -10,27 +10,28 @@ import JS
 --------------------------------------------------------------------------------
 
 ||| A `Cmd` (abbreviation of "command") is a (typically effectful) computation
-||| sending its result to an event handler.
+||| which might send an arbitrary number of events of type `e` to an event
+||| handler synchronously or asynchronously.
+|||
+||| Commands are used as the primary means of setting up (interactive) UI
+||| components and running effectful computations.
+|||
+||| Module `Web.MVC.View` provides various commands for creating, modifying
+||| and deleting interactive DOM elements.
+|||
+||| Module `Web.MVC.Animate` has commands for firing events at regular
+||| intervals and for running animations.
+|||
+||| Module `Web.MVC.Http` has commands for sending requests to and
+||| firing events upon receiving responses from HTTP servers.
 public export
 record Cmd (e : Type) where
   constructor C
-  run : (e -> JSIO ()) -> JSIO ()
+  run : (handler : e -> JSIO ()) -> JSIO ()
 
 export %inline
 Functor Cmd where
   map f (C run) = C $ run . (. f)
-
-bind : {0 a,b : _} -> Cmd a -> (a -> Cmd b) -> Cmd b
-bind (C g) f = C $ \h => g $ \va => run (f va) h
-
-export %inline
-Applicative Cmd where
-  pure v = C $ \h => h v
-  cf <*> cv = bind cf (<$> cv)
-
-export %inline
-Monad Cmd where
-  (>>=) = bind
 
 export
 Semigroup (Cmd e) where
@@ -40,32 +41,59 @@ export %inline
 Monoid (Cmd e) where
   neutral = C . const $ pure ()
 
-||| Wrap a batch of commands in a single command by
-||| running them sequentially.
+||| Wraps a batch of commands in a single command by
+||| installing each command sequentially.
+|||
+||| This function is stack safe.
 export
 batch : List (Cmd e) -> Cmd e
 batch cs = C $ \h => traverseList_ (`run` h) cs
 
 ||| Wrap an effectful computation in a command.
+|||
+||| The produced result is fired synchronously.
 export %inline
 cmd : JSIO e -> Cmd e
 cmd v = C (v >>=)
 
 ||| Wrap an effectful computation in a command.
+|||
+||| The produced result is fired synchronously.
+export %inline
+liftIO : IO e -> Cmd e
+liftIO = cmd . liftIO
+
+||| Wrap an effectful computation in a command.
+|||
+||| This will never fire an event.
 export %inline
 cmd_ : JSIO () -> Cmd e
 cmd_ v = C $ const v
 
+||| Wrap an effectful computation in a command.
+|||
+||| This will never fire an event.
+export %inline
+liftIO_ : IO () -> Cmd e
+liftIO_ = cmd_ . liftIO
+
+||| Fires the given event once, synchronously.
+export %inline
+pure : e -> Cmd e
+pure v = C ($ v)
+
 ||| A command that produces no event.
+|||
+||| This will never fire an event.
 export %inline
 noAction : Cmd e
 noAction = neutral
 
+||| Use the given command conditionally.
+|||
+||| If the boolean flag is `False`, this will return the
+||| empty command (`noAction`).
 export
 updateIf : Bool -> Lazy (Cmd e) -> Cmd e
 updateIf True  u = u
 updateIf False _ = noAction
-
-export %inline
-HasIO Cmd where
-  liftIO = cmd . liftIO

--- a/src/Web/MVC/Cmd.idr
+++ b/src/Web/MVC/Cmd.idr
@@ -94,6 +94,13 @@ noAction = neutral
 ||| If the boolean flag is `False`, this will return the
 ||| empty command (`noAction`).
 export
-updateIf : Bool -> Lazy (Cmd e) -> Cmd e
-updateIf True  u = u
-updateIf False _ = noAction
+cmdIf : Bool -> Lazy (Cmd e) -> Cmd e
+cmdIf True  u = u
+cmdIf False _ = noAction
+
+||| Convert a value in a `Maybe` to a `Cmd e`.
+|||
+||| Returns the empty command in case of a `Nothing`.
+export
+cmdIfJust : Maybe t -> (t -> Cmd e) -> Cmd e
+cmdIfJust m f = maybe noAction f m

--- a/src/Web/MVC/Http.idr
+++ b/src/Web/MVC/Http.idr
@@ -82,24 +82,24 @@ append fd (FilePart name file)    = FormData.append1 fd name file
 
 parameters {0 r    : Type}
 
-  onerror : Handler r => Expect r -> HTTPError -> JSIO ()
-  onerror (ExpectJSON f)   err = handle (f $ Left err)
-  onerror (ExpectString f) err = handle (f $ Left err)
-  onerror (ExpectAny f)    err = handle (f $ Left err)
+  onerror : (r -> JSIO ()) -> Expect r -> HTTPError -> JSIO ()
+  onerror h (ExpectJSON f)   err = h (f $ Left err)
+  onerror h (ExpectString f) err = h (f $ Left err)
+  onerror h (ExpectAny f)    err = h (f $ Left err)
 
-  onsuccess : Handler r => Expect r -> XMLHttpRequest -> JSIO ()
-  onsuccess (ExpectString f)   x = responseText x >>= handle . f . Right
-  onsuccess (ExpectAny f)      x = handle (f $ Right ())
-  onsuccess (ExpectJSON {a} f) x = do
+  onsuccess : (r -> JSIO ()) -> Expect r -> XMLHttpRequest -> JSIO ()
+  onsuccess h (ExpectString f)   x = responseText x >>= h . f . Right
+  onsuccess h (ExpectAny f)      x = h (f $ Right ())
+  onsuccess h (ExpectJSON {a} f) x = do
     s <- responseText x
-    handle . f . mapFst (JSONError s) $ decode s
+    h . f . mapFst (JSONError s) $ decode s
 
-  onload : Handler r => Expect r -> XMLHttpRequest -> JSIO ()
-  onload exp x = do
+  onload : (r -> JSIO ()) -> Expect r -> XMLHttpRequest -> JSIO ()
+  onload h exp x = do
     st   <- status x
     case st >= 200 && st < 300 of
-      False => onerror exp (BadStatus st)
-      True  => onsuccess exp x
+      False => onerror h exp (BadStatus st)
+      True  => onsuccess h exp x
 
   xsend : RequestBody -> XMLHttpRequest -> JSIO ()
   xsend Empty            x = XMLHttpRequest.send x
@@ -120,14 +120,14 @@ parameters {0 r    : Type}
     -> (expect  : Expect r)
     -> (timeout : Maybe Bits32)
     -> Cmd r
-  request m headers url body exp tout = C $ Prelude.do
+  request m headers url body exp tout = C $ \h => Prelude.do
     -- create new Http request
     x <- XMLHttpRequest.new
 
     -- register event listeners
-    XMLHttpRequestEventTarget.onerror x ?> onerror exp NetworkError
-    XMLHttpRequestEventTarget.onload x ?> onload exp x
-    XMLHttpRequestEventTarget.ontimeout x ?> onerror exp Timeout
+    XMLHttpRequestEventTarget.onerror x ?> onerror h exp NetworkError
+    XMLHttpRequestEventTarget.onload x ?> onload h exp x
+    XMLHttpRequestEventTarget.ontimeout x ?> onerror h exp Timeout
 
     -- open url
     open_ x (cast $ show m) url

--- a/src/Web/MVC/Http.idr
+++ b/src/Web/MVC/Http.idr
@@ -110,7 +110,9 @@ parameters {0 r    : Type}
     traverseList_ (append fd) ps
     XMLHttpRequest.send' x (Def . Just $ inject fd)
 
-  ||| Send a HTTP request.
+  ||| Sends a HTTP request.
+  |||
+  ||| Converts the response to an event of type `r`.
   export
   request :
        (method  : Method)

--- a/src/Web/MVC/Util.idr
+++ b/src/Web/MVC/Util.idr
@@ -1,4 +1,4 @@
-module Web.MVC.Output
+module Web.MVC.Util
 
 import JS
 import Text.CSS

--- a/src/Web/MVC/View.idr
+++ b/src/Web/MVC/View.idr
@@ -1,0 +1,303 @@
+module Web.MVC.View
+
+import Control.Monad.Either.Extra
+import Data.Either
+import Data.Maybe
+import Data.String
+import JS
+import Text.CSS
+import Text.HTML
+import Web.Dom
+import Web.Html
+import Web.MVC.Canvas
+import Web.MVC.Cmd
+import Web.MVC.Event
+import Web.MVC.Util
+
+%default total
+
+--------------------------------------------------------------------------------
+--          Registering Events
+--------------------------------------------------------------------------------
+
+parameters {0 e : Type}
+           (h   : e -> JSIO ())
+
+  ||| Low level method for registering `DOMEvents` at
+  ||| HTML elements.
+  |||
+  ||| Use this, for instance, to register `DOMEvents` at
+  ||| a HTMLElement of a static document.
+  export
+  registerDOMEvent :
+       (preventDefault, stopPropagation : Bool)
+    -> EventTarget
+    -> DOMEvent e
+    -> JSIO ()
+  registerDOMEvent prev stop el de = case de of
+    Input f      => inst "input" inputInfo f
+    Change f     => inst "change" changeInfo f
+    Click f      => inst "click" mouseInfo f
+    DblClick f   => inst "dblclick" mouseInfo f
+    KeyDown f    => inst "keydown" keyInfo f
+    KeyUp f      => inst "keyup" keyInfo f
+    Blur v       => inst "blur" {t = Event} (const $ pure v) Just
+    Focus v      => inst "focus" {t = Event} (const $ pure v) Just
+    MouseDown f  => inst "mousedown" mouseInfo f
+    MouseUp f    => inst "mouseup" mouseInfo f
+    MouseEnter f => inst "mouseenter" mouseInfo f
+    MouseLeave f => inst "mouseleave" mouseInfo f
+    MouseOver f  => inst "mouseover" mouseInfo f
+    MouseOut f   => inst "mouseout" mouseInfo f
+    MouseMove f  => inst "mousemove" mouseInfo f
+    HashChange v => inst "hashchange" {t = Event} (const $ pure v) Just
+    Wheel f      => inst "wheel" wheelInfo f
+
+    where
+      inst :
+           {0 t,b : _}
+        -> {auto c : SafeCast t}
+        -> String
+        -> (t -> JSIO b)
+        -> (b -> Maybe e)
+        -> JSIO ()
+      inst {t} s conv f = do
+        c <- callback {cb = EventListener} $ \e => do
+          canc <- cancelable e
+          bubl <- bubbles e
+          when (canc && prev) (preventDefault e)
+          when (bubl && stop) (stopPropagation e)
+          va <- tryCast_ t "Web.MVC.View.inst" e
+          conv va >>= maybe (pure ()) h . f
+
+        addEventListener el s (Just c)
+
+  export
+  setAttribute : Element -> Attribute t e -> JSIO ()
+  setAttribute el (Id (Id value))   = setAttribute el "id" value
+  setAttribute el (Str name value)  = setAttribute el name value
+  setAttribute el (Bool name value) = case value of
+    True  => setAttribute el name ""
+    False => removeAttribute el name
+  setAttribute el (Event_ prev stop ev) = registerDOMEvent prev stop(up el) ev
+  setAttribute el Empty      = pure ()
+
+
+--------------------------------------------------------------------------------
+--          Node Preparation
+--------------------------------------------------------------------------------
+
+  addNodes :
+       {auto 0 _ : JSType t}
+    -> {auto 0 _ : Elem ParentNode (Types t)}
+    -> (doc      : Document)
+    -> (parent   : t)
+    -> (nodes    : List (Node e))
+    -> JSIO ()
+
+  addNode :
+       {auto 0 _ : JSType t}
+    -> {auto 0 _ : Elem ParentNode (Types t)}
+    -> (doc      : Document)
+    -> (parent   : t)
+    -> (node     : Node e)
+    -> JSIO ()
+  addNode doc p (El {tag} _ xs ys) = do
+    n <- createElement doc tag
+    append p [inject $ n :> Node]
+    addNodes doc n ys
+    traverseList_ (setAttribute n) xs
+
+  addNode doc p (Raw str) = do
+    el <- createElement doc "template"
+    Just temp <- pure (castTo HTMLTemplateElement el) | Nothing => pure ()
+    innerHTML temp .= str
+    c         <- content temp
+    append p [inject $ c :> Node]
+
+  addNode doc p (Text str) = append p [inject str]
+
+  addNode doc p Empty      = pure ()
+
+  addNodes doc p = assert_total $ traverseList_ (addNode doc p)
+
+setupNodes :
+     (Element -> DocumentFragment -> JSIO ())
+  -> Ref t
+  -> List (Node e)
+  -> Cmd e
+setupNodes adj r ns = C $ \h => do
+  doc  <- document
+  elem <- castElementByRef {t = Element} r
+  df   <- createDocumentFragment doc
+  addNodes h doc df ns
+  adj elem df
+
+%inline
+setupNode :
+     (Element -> DocumentFragment -> JSIO ())
+  -> Ref t
+  -> Node e
+  -> Cmd e
+setupNode adj r n = setupNodes adj r [n]
+
+||| Sets up the reactive behavior of the given `Node`s and
+||| inserts them as the children of the given target.
+export %inline
+children : Ref t -> List (Node e) -> Cmd e
+children = setupNodes replaceChildren
+
+||| Sets up the reactive behavior of the given `Node` and
+||| inserts it as the only child of the given target.
+export %inline
+child : Ref t -> Node e -> Cmd e
+child = setupNode replaceChildren
+
+||| Replaces the given node's children with a text node
+||| displaying the given string.
+export %inline
+text : Ref t -> String -> Cmd e
+text r = child r . Text
+
+||| Replaces the given node's children with a text node
+||| showing the given value.
+export %inline
+show : Show b => Ref t -> b -> Cmd e
+show r = text r . show
+
+||| Replaces the given node's children with the raw
+||| HTML passed as a string argument.
+export %inline
+raw : Ref t -> String -> Cmd e
+raw r = child r . Raw
+
+||| Replaces the given `<style>` node's CSS rules.
+export
+style : Ref Tag.Style -> List (Rule 1) -> Cmd e
+style r rules =
+  let str := fastUnlines $ map interpolate rules
+   in raw r str
+
+||| Sets up the reactive behavior of the given `Node`s and
+||| inserts them after the given child node.
+export %inline
+afterMany : Ref t -> List (Node e) -> Cmd e
+afterMany = setupNodes afterDF
+
+||| Sets up the reactive behavior of the given `Node` and
+||| inserts it after the given child node.
+export %inline
+after : Ref t -> Node e -> Cmd e
+after = setupNode afterDF
+
+||| Sets up the reactive behavior of the given `Node`s and
+||| inserts them before the given child node.
+export %inline
+beforeMany : Ref t -> List (Node e) -> Cmd e
+beforeMany = setupNodes beforeDF
+
+||| Sets up the reactive behavior of the given `Node` and
+||| inserts it before the given child node.
+export %inline
+before : Ref t -> Node e -> Cmd e
+before = setupNode beforeDF
+
+||| Sets up the reactive behavior of the given `Node`s and
+||| appends them to the given element's list of children
+export %inline
+appendMany : Ref t -> List (Node e) -> Cmd e
+appendMany = setupNodes appendDF
+
+||| Sets up the reactive behavior of the given `Node` and
+||| appends it to the given element's list of children
+export %inline
+append : Ref t -> Node e -> Cmd e
+append = setupNode appendDF
+
+||| Sets up the reactive behavior of the given `Node`s and
+||| prepends them to the given element's list of children
+export %inline
+prependMany : Ref t -> List (Node e) -> Cmd e
+prependMany = setupNodes prependDF
+
+||| Sets up the reactive behavior of the given `Node` and
+||| prepends it to the given element's list of children
+export %inline
+prepend : Ref t -> Node e -> Cmd e
+prepend = setupNode prependDF
+
+||| Sets up the reactive behavior of the given `Node`s and
+||| replaces the given element.
+export %inline
+replaceMany : Ref t -> List (Node e) -> Cmd e
+replaceMany = setupNodes replaceDF
+
+||| Sets up the reactive behavior of the given `Node` and
+||| replaces the given element.
+export %inline
+replace : Ref t -> Node e -> Cmd e
+replace = setupNode replaceDF
+
+||| Sets a custom validity message at the given node.
+export %inline
+validityMsg : Ref t -> ValidityTag t => String -> Cmd e
+validityMsg r s = cmd_ $ setValidityMessage r s
+
+||| Sets or unsets a custom validity message at the given node.
+export
+validate : Ref t -> ValidityTag t => Either String b -> Cmd e
+validate r (Left s)  = validityMsg r s
+validate r (Right s) = validityMsg r ""
+
+||| Sets an attribute at the given node.
+export
+attr : Ref t -> Attribute t e -> Cmd e
+attr r a = C $ \h => castElementByRef r >>= \el => setAttribute h el a
+
+||| Sets the `disabled` attribute of the given element
+export %inline
+disabled : Ref t -> Bool -> Cmd e
+disabled r = attr r . disabled
+
+||| Sets the `disabled` attribute of the given element
+||| if the given values is a `Left`.
+|||
+||| This is useful for disabling components such as buttons
+||| in the UI in case of invalid user input.
+export %inline
+disabledE : {0 a,b : _} -> Ref t -> Either a b -> Cmd e
+disabledE r = disabled r . isLeft
+
+||| Sets the `disabled` attribute of the given element
+||| if the given values is a `Nothing`.
+|||
+||| This is useful for disabling components such as buttons
+||| in the UI in case of invalid user input.
+export %inline
+disabledM : {0 a : _} -> Ref t -> Maybe a -> Cmd e
+disabledM r = disabled r . isNothing
+
+||| Removes the given element from the DOM.
+export
+remove : Ref t -> Cmd e
+remove r = cmd_ (castElementByRef {t = Element} r >>= remove)
+
+||| Sets the `value` attribute of the given element.
+export %inline
+value : Ref t -> ValueTag t => String -> Cmd e
+value r s = cmd_ (setValue r s)
+
+||| Renders a scene at a canvas element
+export %inline
+renderWithDims : Ref Tag.Canvas -> (CanvasDims -> Scene) -> Cmd e
+renderWithDims r s = cmd_ (render r s)
+
+||| Renders a scene at a canvas element
+export %inline
+render : Ref Tag.Canvas -> Scene -> Cmd e
+render r = renderWithDims r . const
+
+||| Focus the given HTMLElemet
+export %inline
+focus : Ref t -> Cmd e
+focus r = cmd_ (castElementByRef {t = HTMLElement} r >>= HTMLOrSVGElement.focus)


### PR DESCRIPTION
After reading more about how `Cmd` and `Subs` are implemented in Elm, our own `Cmd` type is adjusted accordingly. This brings us much closer to how Elm does thing. There is still no virtual DOM or `View`, however: All updates to the UI occur via commands. The result is - in my opinion - very satisfying. We get a clean way to support timers, animations, and effectful computations via `Cmd`s.

Function `runController` had to be adjusted to support the synchronous firing of events while other events are being processed by collecting those additional events in an event queue (what Elm does as well). This is necessary to support effectful stuff like random value generation in `Cmd`s. It also allows us to fire pure follow up events in case we need to cleanup the application state *after* a command was issued.

Hopefully, this addresses some questions from #24 and smoothens the learning curve especially for people coming from Elm.