### PR TITLE
[ refactor ] provide a pure way to work with TextMetrics

### DIFF
--- a/src/Web/MVC/Canvas.idr
+++ b/src/Web/MVC/Canvas.idr
@@ -38,13 +38,18 @@ context2D canvas = do
     Just c  => pure c
     Nothing => throwError $ Caught "Web.MVC.Canvas.context2d: No rendering context for canvas"
 
-||| Render a seen in a canvas in the DOM.
+||| Render a scene in a canvas in the DOM.
 export
-render : Ref Canvas -> (CanvasDims -> Scene) -> JSIO ()
-render ref scene = do
+renderWithMetrics : Ref Canvas -> (TextMeasure => CanvasDims -> Scene) -> JSIO ()
+renderWithMetrics ref scene = do
   canvas <- castElementByRef {t = HTMLCanvasElement} ref
   ctxt   <- context2D canvas
   w      <- cast <$> get canvas width
   h      <- cast <$> get canvas height
   apply ctxt $ Rect 0 0 w h Clear
-  apply ctxt (scene (CD w h))
+  applyWithMetrics ctxt (scene (CD w h))
+
+||| Render a scene in a canvas in the DOM.
+export %inline
+render : Ref Canvas -> (CanvasDims -> Scene) -> JSIO ()
+render ref scene = renderWithMetrics ref scene

--- a/src/Web/MVC/Canvas/Scene.idr
+++ b/src/Web/MVC/Canvas/Scene.idr
@@ -64,8 +64,11 @@ export
 %foreign "browser:lambda:x=>x.width"
 width : TextMetrics -> Double
 
-%foreign "browser:lambda:(c,f,s)=>{f1 = c.font; c.font = f; res = c.measureText(s); c.font = f1; return res}"
-prim__measureText : CanvasRenderingContext2D -> (font, text : String) -> TextMetrics
+%foreign "browser:lambda:(c,d,a,b,f,s)=>{d0 = c.direction; b0 = c.textBaseline; a0 = c.textAlign; f0 = c.font; c.font = f; c.direction = d; c.textBaseline = b; c.textAlign = a; res = c.measureText(s); c.font = f0; c.direction = d0; c.textBaseline = b0; c.textAlign = a0; return res}"
+prim__measureText :
+     CanvasRenderingContext2D
+  -> (dir, align, baseline, font, text : String)
+  -> TextMetrics
 
 --------------------------------------------------------------------------------
 --          Scene
@@ -103,16 +106,22 @@ apply ctxt (SM fs tr xs) = do
   restore  ctxt
 
 ||| Utility for computing `TextMetrics`.
-public export
+export
 record TextMeasure where
   [noHints]
   constructor TM
-  measure_ : (font, text : String) -> TextMetrics
+  measure_ : (dir, align, bl, font, text : String) -> TextMetrics
 
 ||| Compute the `TextMetrics` for the given text in the given font.
 export %inline
-measureText : (m : TextMeasure) => (font,text : String) -> TextMetrics
-measureText f t = m.measure_ f t
+measureText :
+     {auto m : TextMeasure}
+  -> CanvasDirection
+  -> CanvasTextAlign
+  -> CanvasTextBaseline
+  -> (font,text : String)
+  -> TextMetrics
+measureText d a b f t = m.measure_ (show d) (show a) (show b) f t
 
 ||| Alternative version of `apply` for those cases where we need to
 ||| work with text metrics.

--- a/src/Web/MVC/View.idr
+++ b/src/Web/MVC/View.idr
@@ -295,6 +295,11 @@ value r s = cmd_ (setValue r s)
 
 ||| Renders a scene at a canvas element
 export %inline
+renderWithMetrics : Ref Tag.Canvas -> (TextMeasure => CanvasDims -> Scene) -> Cmd e
+renderWithMetrics r s = cmd_ (renderWithMetrics r s)
+
+||| Renders a scene at a canvas element
+export %inline
 renderWithDims : Ref Tag.Canvas -> (CanvasDims -> Scene) -> Cmd e
 renderWithDims r s = cmd_ (render r s)
 


### PR DESCRIPTION
Computing `TextMetrics` is the only way to get the correct size of a piece of text in the canvas. So far, we used a clumsy hack to make text metrics available to client code. With this PR, we still use a hack (in form of an auto-implicit utility for computing text metrics, which is derived from `CanvasRenderingContext2D`), but it's far less clumsy.